### PR TITLE
Fix lint errors with minimal changes

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -37,6 +37,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
+const (
+	defaultTimeoutMinutes = 5
+	escapeSequenceCode    = 29
+	bufferSize            = 1024
+)
+
 type consoleCommand struct {
 	timeout int
 }
@@ -50,7 +56,8 @@ func NewCommand() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE:    c.run,
 	}
-	cmd.Flags().IntVar(&c.timeout, "timeout", 5, "The number of minutes to wait for the virtual machine instance to be ready.")
+	cmd.Flags().IntVar(&c.timeout, "timeout", defaultTimeoutMinutes,
+		"The number of minutes to wait for the virtual machine instance to be ready.")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 	return cmd
 }
@@ -88,7 +95,8 @@ func (c *consoleCommand) handleConsoleConnection(client kubecli.KubevirtClient, 
 	signal.Notify(waitInterrupt, os.Interrupt)
 
 	go func() {
-		con, err := client.VirtualMachineInstance(namespace).SerialConsole(vmi, &kvcorev1.SerialConsoleOptions{ConnectionTimeout: time.Duration(c.timeout) * time.Minute})
+		con, err := client.VirtualMachineInstance(namespace).SerialConsole(vmi,
+			&kvcorev1.SerialConsoleOptions{ConnectionTimeout: time.Duration(c.timeout) * time.Minute})
 		runningChan <- err
 
 		if err != nil {
@@ -131,16 +139,22 @@ func (c *consoleCommand) handleConsoleConnection(client kubecli.KubevirtClient, 
 // Attach attaches stdin and stdout to the console
 // in -> stdinWriter | stdinReader -> console
 // out <- stdoutReader | stdoutWriter <- console
-func Attach(stdinReader, stdoutReader *io.PipeReader, stdinWriter, stdoutWriter *io.PipeWriter, message string, resChan <-chan error) (err error) {
+func Attach(stdinReader, stdoutReader *io.PipeReader, stdinWriter, stdoutWriter *io.PipeWriter,
+	message string, resChan <-chan error) (err error) {
 	stopChan := make(chan struct{}, 1)
 	writeStop := make(chan error)
 	readStop := make(chan error)
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		state, err := term.MakeRaw(int(os.Stdin.Fd()))
-		if err != nil {
-			return fmt.Errorf("Make raw terminal failed: %s", err)
+		state, makeRawErr := term.MakeRaw(int(os.Stdin.Fd()))
+		if makeRawErr != nil {
+			return fmt.Errorf("make raw terminal failed: %s", makeRawErr)
 		}
-		defer term.Restore(int(os.Stdin.Fd()), state)
+		defer func() {
+			if restoreErr := term.Restore(int(os.Stdin.Fd()), state); restoreErr != nil {
+				// Log the error but don't return it since we're in a defer
+				fmt.Fprintf(os.Stderr, "Failed to restore terminal: %v\n", restoreErr)
+			}
+		}()
 	}
 	fmt.Fprint(os.Stderr, message)
 
@@ -155,31 +169,31 @@ func Attach(stdinReader, stdoutReader *io.PipeReader, stdinWriter, stdoutWriter 
 	}()
 
 	go func() {
-		_, err := io.Copy(out, stdoutReader)
-		readStop <- err
+		_, copyErr := io.Copy(out, stdoutReader)
+		readStop <- copyErr
 	}()
 
 	go func() {
 		defer close(writeStop)
-		buf := make([]byte, 1024, 1024)
+		buf := make([]byte, bufferSize)
 		for {
 			// reading from stdin
-			n, err := in.Read(buf)
-			if err != nil && err != io.EOF {
-				writeStop <- err
+			n, readErr := in.Read(buf)
+			if readErr != nil && readErr != io.EOF {
+				writeStop <- readErr
 				return
 			}
-			if n == 0 && err == io.EOF {
+			if n == 0 && readErr == io.EOF {
 				return
 			}
 
 			// the escape sequence
-			if buf[0] == 29 {
+			if buf[0] == escapeSequenceCode {
 				return
 			}
 			// Writing out to the console connection
-			_, err = stdinWriter.Write(buf[0:n])
-			if err == io.EOF {
+			_, writeErr := stdinWriter.Write(buf[0:n])
+			if writeErr == io.EOF {
 				return
 			}
 		}


### PR DESCRIPTION
```
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR addresses and fixes various linting errors identified in `pkg/virtctl/console/console.go`.

#### Before this PR:
The file `pkg/virtctl/console/console.go` contained the following linting issues:
- Unchecked error return value from `term.Restore`.
- Non-`gofumpt`-ed formatting.
- Lines exceeding the 140-character limit (`lll`).
- Redundant capacity specification in `make([]byte, 1024, 1024)` (`gosimple`).
- Variable shadowing (`govet`).
- Use of magic numbers (`mnd`).

#### After this PR:
All identified linting errors in `pkg/virtctl/console/console.go` are resolved, leading to improved code readability, maintainability, and adherence to Go best practices.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issue/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
This PR is necessary to improve the overall code quality and maintainability of the `virtctl` console component by resolving existing linting violations. The changes were made with a focus on minimalism, directly addressing each specific lint error. This includes:
- Introducing named constants for magic numbers.
- Renaming shadowed variables for clarity.
- Breaking long lines to meet character limits.
- Ensuring `term.Restore` errors are handled (logged to stderr).
- Applying standard Go formatting.

The following tradeoffs were made:
- For `term.Restore` error, logging to `stderr` was chosen as it's a `defer` function and cannot return an error to the caller. This ensures the error is noted without disrupting the main flow.

The following alternatives were considered:
- N/A, direct lint fixes were the primary goal.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- The error return value of `term.Restore` is now checked and logged to `os.Stderr` within its `defer` function, as errors from `defer` cannot be propagated.
- Variable shadowing issues were resolved by renaming the shadowed `err` variables to more specific names (e.g., `makeRawErr`, `copyErr`, `readErr`, `writeErr`).
- Magic numbers `5` (timeout) and `29` (escape sequence) have been replaced with descriptive named constants.
- Long lines in the `SerialConsole` call and `Attach` function signature have been broken for readability.
- The `make([]byte, 1024, 1024)` was simplified to `make([]byte, bufferSize)`.
- The file has been formatted according to `gofumpt -extra`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```